### PR TITLE
attempt to fix threefold repetition bug on pv

### DIFF
--- a/internal/engine/position.go
+++ b/internal/engine/position.go
@@ -270,7 +270,10 @@ func (pos *Position) getBitboards(side Color) (bitboards []Bitboard) {
 
 // isDraw returns if the current position is a draw by repetition, 50 move rule or insuficient material
 func (pos *Position) isDraw() bool {
-	return pos.positionHistory.repetitionCount(pos.Hash, pos.halfmoveClock) >= 2 ||
+	// Instead of waiting to get a threefold repetition, Aconcagua assumes
+	// if a position is repeated once, it should be at least a draw. This helps
+	// avoid unecessary search and seems working well.
+	return pos.positionHistory.isRepetition(pos.Hash, pos.halfmoveClock) ||
 		pos.halfmoveClock >= 100 ||
 		pos.insuficientMaterial()
 }
@@ -654,6 +657,8 @@ func (pos *Position) LoadFromFenString(fen string) {
 	pos.FullMoveNumber, _ = strconv.Atoi(elements[5])
 
 	pos.Hash = zobristHashKeys.fullZobristHash(pos)
+	pos.positionHistory.previousPosition[0] = pos.Hash
+	pos.positionHistory.moveCount = 1
 	pos.PawnHash = zobristHashKeys.pawnHash(pos)
 }
 

--- a/internal/engine/position_history.go
+++ b/internal/engine/position_history.go
@@ -10,22 +10,21 @@ type PositionHistory struct {
 	moveCount            int
 }
 
-// repetitionCount counts how many times a position appeared
-func (ph *PositionHistory) repetitionCount(hash uint64, halfmoveClock int) int {
-	reps := 0
-
+// isRepetition returns if the position has been repeated in the current search
+func (ph *PositionHistory) isRepetition(hash uint64, halfmoveClock int) bool {
 	// Calculate search limit based on halfmove clock
+	// A repetition cannot never occur after a halfmove clock reset
 	lastIrreversibleMove := max(ph.moveCount-halfmoveClock, 0)
 
 	// Check all positions back to the last irreversible move
 	// Only check positions with same side to move (every 2 plies)
 	for i := ph.moveCount - 2; i >= lastIrreversibleMove; i -= 2 {
 		if ph.previousPosition[i] == hash {
-			reps++
+			return true
 		}
 	}
 
-	return reps
+	return false
 }
 
 // clear clears the position history


### PR DESCRIPTION
Count only up to 1 repetition, instead of 3. This seems working well and the pv never shows an illegal move by repetition any more. I need to validate with the sprt test